### PR TITLE
refs #4 - DTOs und Modelle für `Artikel` und `Katalog` mit dynamische…

### DIFF
--- a/asset-service/src/main/java/com/sakai/inventory/api/dto/ArticleDTO.java
+++ b/asset-service/src/main/java/com/sakai/inventory/api/dto/ArticleDTO.java
@@ -5,16 +5,4 @@ import java.util.Map;
 public record ArticleDTO(String articleId, String name, String sku, String description, String price, Long inventory,
                          String imageUrl, String catalogId, Boolean isActive, Boolean isFeatured,
                          Map<String, DynamicFieldsDTO> dynamicFields, String createdAt, String updatedAt) {
-//    id?: string;
-//    name: string;
-//    sku: string;
-//    description?: string;
-//    price?: number;
-//    stock?: number;
-//    imageUrl?: string;
-//    catalogId?: string;
-//    active: boolean;
-//    featured: boolean;
-//    dynamicFields: DynamicField[];
-//    createdAt?: string;
 }

--- a/asset-service/src/main/java/com/sakai/inventory/api/dto/ArticleDTO.java
+++ b/asset-service/src/main/java/com/sakai/inventory/api/dto/ArticleDTO.java
@@ -1,0 +1,20 @@
+package com.sakai.inventory.api.dto;
+
+import java.util.Map;
+
+public record ArticleDTO(String articleId, String name, String sku, String description, String price, Long inventory,
+                         String imageUrl, String catalogId, Boolean isActive, Boolean isFeatured,
+                         Map<String, DynamicFieldsDTO> dynamicFields, String createdAt, String updatedAt) {
+//    id?: string;
+//    name: string;
+//    sku: string;
+//    description?: string;
+//    price?: number;
+//    stock?: number;
+//    imageUrl?: string;
+//    catalogId?: string;
+//    active: boolean;
+//    featured: boolean;
+//    dynamicFields: DynamicField[];
+//    createdAt?: string;
+}

--- a/asset-service/src/main/java/com/sakai/inventory/api/dto/CatalogDTO.java
+++ b/asset-service/src/main/java/com/sakai/inventory/api/dto/CatalogDTO.java
@@ -1,0 +1,11 @@
+package com.sakai.inventory.api.dto;
+
+public record CatalogDTO(String catalogId, String name, String description, String color, Integer productCount,
+                         String createdAt, String updatedAt) {
+//    id?: string;
+//    name: string;
+//    description?: string;
+//    color: string;
+//    productCount?: number;
+//    createdAt?: string;
+}

--- a/asset-service/src/main/java/com/sakai/inventory/api/dto/CatalogDTO.java
+++ b/asset-service/src/main/java/com/sakai/inventory/api/dto/CatalogDTO.java
@@ -2,10 +2,4 @@ package com.sakai.inventory.api.dto;
 
 public record CatalogDTO(String catalogId, String name, String description, String color, Integer productCount,
                          String createdAt, String updatedAt) {
-//    id?: string;
-//    name: string;
-//    description?: string;
-//    color: string;
-//    productCount?: number;
-//    createdAt?: string;
 }

--- a/asset-service/src/main/java/com/sakai/inventory/api/dto/DynamicFieldsDTO.java
+++ b/asset-service/src/main/java/com/sakai/inventory/api/dto/DynamicFieldsDTO.java
@@ -1,7 +1,4 @@
 package com.sakai.inventory.api.dto;
 
 public record DynamicFieldsDTO(String name, String type, Object value) {
-//    name: string;
-//    type: 'text' | 'number' | 'boolean' | 'date';
-//    value: any;
 }

--- a/asset-service/src/main/java/com/sakai/inventory/api/dto/DynamicFieldsDTO.java
+++ b/asset-service/src/main/java/com/sakai/inventory/api/dto/DynamicFieldsDTO.java
@@ -1,0 +1,7 @@
+package com.sakai.inventory.api.dto;
+
+public record DynamicFieldsDTO(String name, String type, Object value) {
+//    name: string;
+//    type: 'text' | 'number' | 'boolean' | 'date';
+//    value: any;
+}

--- a/asset-service/src/main/java/com/sakai/inventory/api/handler/GetCatalogsHandler.java
+++ b/asset-service/src/main/java/com/sakai/inventory/api/handler/GetCatalogsHandler.java
@@ -4,10 +4,17 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.sakai.inventory.api.dto.ArticleDTO;
+import com.sakai.inventory.api.model.Article;
+import com.sakai.inventory.api.model.DynamicFieldValue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import utility.Utility;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class GetCatalogsHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -24,16 +31,246 @@ public class GetCatalogsHandler implements RequestHandler<APIGatewayProxyRequest
         headers.put("X-Custom-Header", "application/json");
 
         String body = String.format("{\"message\": \"Lambda works successfully\"}");
+        List<Article> articles = fetchArticles();
+        List<ArticleDTO> articleDTOs = mapArticles(articles);
 
         APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent();
 
         response.setHeaders(headers);
-        response.setBody(body);
-        response.setStatusCode(200);
+        try {
+            response.setBody(Utility.objectMapper.writeValueAsString(articleDTOs));
+            response.setStatusCode(200);
+            LOGGER.info("GetCatalogsHandler request successful");
+        } catch (JsonProcessingException e) {
+            response.setStatusCode(500);
+            response.setBody("{}");
+        }
 
-        LOGGER.info("GetCatalogsHandler request successful");
         LOGGER.info("GetCatalogsHandler response: {}", response.getBody());
 
         return response;
+    }
+
+    private List<ArticleDTO> mapArticles(List<Article> articles) {
+        List<ArticleDTO> articleDTOS = new ArrayList<>();
+
+        for (Article article : articles) {
+            articleDTOS.add(new ArticleDTO(
+                    article.getArticleId(),
+                    article.getName(),
+                    article.getSku(),
+                    article.getDescription(),
+                    article.getPrice(),
+                    article.getInventory(),
+                    article.getImageUrl(),
+                    article.getCatalogId(),
+                    true,
+                    true,
+                    new HashMap<>(),
+                    article.getCreatedAt(),
+                    article.getUpdatedAt()));
+        }
+
+        return articleDTOS;
+    }
+
+    private List<Article> fetchArticles() {
+
+        DynamicFieldValue dynamicFieldValue1 = new DynamicFieldValue();
+        dynamicFieldValue1.setName("provenance");
+        dynamicFieldValue1.setType("text");
+        dynamicFieldValue1.setValue("Sammlung Dr. Schmidt, Auktion Haus Müller 2019");
+
+        DynamicFieldValue dynamicFieldValue2 = new DynamicFieldValue();
+        dynamicFieldValue2.setName("exhibitions");
+        dynamicFieldValue2.setValue("Biennale Venedig 2023");
+        dynamicFieldValue2.setType("text");
+
+        Map<String, DynamicFieldValue> dynamicField1 = new HashMap<>();
+        dynamicField1.put("artist", dynamicFieldValue1);
+        Map<String, DynamicFieldValue> dynamicField2 = new HashMap<>();
+        dynamicField2.put("exhibitions", dynamicFieldValue2);
+
+        return List.of(
+                createArticle(
+                        "ART-001",
+                        "SKU-7001",
+                        "Antike Vase aus der Ming-Dynastie",
+                        "Eine gut erhaltene Porzellanvase mit blau-weißen Mustern, ca. 16. Jahrhundert.",
+                        "Nicht bewertet",
+                        1L,
+                        "https://inventory-images.s3.eu-central-1.amazonaws.com/ming_vase.jpg",
+                        "AVAILABLE",
+                        true,
+                        "CAT-ANTIQUES",
+                        "2024-01-15T10:30:00Z",
+                        "2024-03-10T14:22:00Z",
+                        new HashMap<>()
+                ),
+                // Artikel 2 (OHNE dynamische Felder)
+                createArticle(
+                        "ART-002",
+                        "SKU-7002",
+                        "Barock-Gemälde 'Landschaft mit Fluss'",
+                        "Öl auf Leinwand, 18. Jahrhundert, Rahmen original.",
+                        "Nicht bewertet",
+                        1L,
+                        "https://inventory-images.s3.eu-central-1.amazonaws.com/barock_painting.jpg",
+                        "UNDER_EVALUATION",
+                        false,
+                        "CAT-PAINTINGS",
+                        "2024-02-01T09:15:00Z",
+                        "2024-02-28T16:45:00Z",
+                        new HashMap<>()
+                ),
+                // Artikel 3 (MIT dynamischen Feldern - Provenienz und Material)
+                createArticle(
+                        "ART-003",
+                        "SKU-7003",
+                        "Renaissance-Bronzeskulptur 'Reiter'",
+                        "Kleine Bronzestatue, italienische Arbeit, 17. Jahrhundert.",
+                        "Nicht bewertet",
+                        1L,
+                        "https://inventory-images.s3.eu-central-1.amazonaws.com/bronze_rider.jpg",
+                        "AVAILABLE",
+                        true,
+                        "CAT-SCULPTURES",
+                        "2023-11-20T11:00:00Z",
+                        "2024-01-05T12:30:00Z",
+                        dynamicField1
+                ),
+                // Artikel 4 (OHNE dynamische Felder)
+                createArticle(
+                        "ART-004",
+                        "SKU-7004",
+                        "Art Deco Sekretär aus Nussbaum",
+                        "Möbelstück mit Intarsien, Frankreich um 1925.",
+                        "Nicht bewertet",
+                        1L,
+                        "https://inventory-images.s3.eu-central-1.amazonaws.com/artdeco_desk.jpg",
+                        "SOLD",
+                        false,
+                        "CAT-FURNITURE",
+                        "2023-10-05T14:20:00Z",
+                        "2024-03-15T10:10:00Z",
+                        new HashMap<>()
+                ),
+                // Artikel 5 (OHNE dynamische Felder)
+                createArticle(
+                        "ART-005",
+                        "SKU-7005",
+                        "Samurai-Rüstung (Gusoku)",
+                        "Komplette Rüstung aus Eisen, Seide und Leder, Edo-Periode.",
+                        "Nicht bewertet",
+                        1L,
+                        "https://inventory-images.s3.eu-central-1.amazonaws.com/samurai_armor.jpg",
+                        "AVAILABLE",
+                        true,
+                        "CAT-ARMOR",
+                        "2024-03-01T08:45:00Z",
+                        "2024-03-01T08:45:00Z",
+                        new HashMap<>()
+                ),
+                // Artikel 6 (OHNE dynamische Felder)
+                createArticle(
+                        "ART-006",
+                        "SKU-7006",
+                        "Persischer Teppich 'Isfahan'",
+                        "Handgeknüpfter Seidenteppich, 2.3 x 1.6 m, Anfang 20. Jh.",
+                        "Nicht bewertet",
+                        1L,
+                        "https://inventory-images.s3.eu-central-1.amazonaws.com/isfahan_carpet.jpg",
+                        "UNDER_EVALUATION",
+                        false,
+                        "CAT-TEXTILES",
+                        "2024-02-10T13:10:00Z",
+                        "2024-02-25T09:30:00Z",
+                        new HashMap<>()
+                ),
+                // Artikel 7 (MIT dynamischen Feldern - Künstler und Technik)
+                createArticle(
+                        "ART-007",
+                        "SKU-7007",
+                        "Moderne Skulptur 'Equilibrium'",
+                        "Abstrakte Stahlskulptur des zeitgenössischen Künstlers M. Chen.",
+                        "Nicht bewertet",
+                        1L,
+                        "https://inventory-images.s3.eu-central-1.amazonaws.com/equilibrium_sculpture.jpg",
+                        "AVAILABLE",
+                        true,
+                        "CAT-MODERN",
+                        "2024-01-30T16:00:00Z",
+                        "2024-03-12T11:20:00Z",
+                        dynamicField2
+                ),
+                // Artikel 8 (OHNE dynamische Felder)
+                createArticle(
+                        "ART-008",
+                        "SKU-7008",
+                        "Klassische Violine 'Stradivarius-Kopie'",
+                        "Geige deutscher Arbeit um 1900, ausgezeichneter Klang.",
+                        "Nicht bewertet",
+                        1L,
+                        "https://inventory-images.s3.eu-central-1.amazonaws.com/violin_strad_copy.jpg",
+                        "AVAILABLE",
+                        false,
+                        "CAT-MUSIC",
+                        "2023-12-15T10:45:00Z",
+                        "2024-02-20T15:15:00Z",
+                        new HashMap<>()
+                ),
+                // Artikel 9 (OHNE dynamische Felder)
+                createArticle(
+                        "ART-009",
+                        "SKU-7009",
+                        "Ägyptische Uschebti-Figur",
+                        "Fayence-Statuette, Spätzeit, für Grabbeigabe bestimmt.",
+                        "Nicht bewertet",
+                        1L,
+                        "https://inventory-images.s3.eu-central-1.amazonaws.com/ushabti_figure.jpg",
+                        "RESERVED",
+                        false,
+                        "CAT-ANTIQUITIES",
+                        "2024-02-28T12:30:00Z",
+                        "2024-03-14T17:00:00Z",
+                        new HashMap<>()
+                ),
+                // Artikel 10 (OHNE dynamische Felder)
+                createArticle(
+                        "ART-010",
+                        "SKU-7010",
+                        "Jugendstil-Vase von Émile Gallé",
+                        "Glasvase mit eingeschliffenen Pflanzendekoren, Frankreich um 1900.",
+                        "Nicht bewertet",
+                        1L,
+                        "https://inventory-images.s3.eu-central-1.amazonaws.com/galle_vase.jpg",
+                        "AVAILABLE",
+                        true,
+                        "CAT-GLASS",
+                        "2024-01-10T09:30:00Z",
+                        "2024-03-05T14:05:00Z",
+                        new HashMap<>()
+                )
+        );
+    }
+
+    private Article createArticle(String articleId, String sku, String name, String description, String price,
+                                  Long inventory, String imageUrl, String state, Boolean isFeatured, String catalogId,
+                                  String createdAt, String updatedAt, Map<String, DynamicFieldValue> dynamicFields) {
+
+        Article article = new Article(name, sku);
+        article.setArticleId(articleId);
+        article.setDescription(description);
+        article.setPrice(price);
+        article.setInventory(inventory);
+        article.setImageUrl(imageUrl);
+        article.setState(state);
+        article.setFeatured(isFeatured);
+        article.setCatalogId(catalogId);
+        article.setCreatedAt(createdAt);
+        article.setUpdatedAt(updatedAt);
+        article.setDynamicFields(dynamicFields);
+
+        return article;
     }
 }

--- a/asset-service/src/main/java/com/sakai/inventory/api/model/Article.java
+++ b/asset-service/src/main/java/com/sakai/inventory/api/model/Article.java
@@ -1,0 +1,156 @@
+package com.sakai.inventory.api.model;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
+
+import java.util.Map;
+
+@DynamoDbBean
+public class Article {
+    private String articleId;
+    private String sku;
+    private String name;
+    private String description;
+    // TODO: muss später entfernt werden. Keine Preise, da kein Handel. Den Wert bestimmt Gutachten.
+    private String price;
+    private Long inventory;
+    private String imageUrl;
+    private String state;
+    private Boolean isFeatured;
+    private String catalogId; // Fremdschlüssel-Referenz.
+
+    private String createdAt;
+    private String updatedAt;
+
+    // Die "Magie" für dynamische Felder.
+    private Map<String, DynamicFieldValue> dynamicFields;
+
+    public Article(String name, String sku) {
+        this.name = name;
+        this.sku = sku;
+    }
+
+    @DynamoDbPartitionKey
+    public String getArticleId() {
+        return articleId;
+    }
+
+    public void setArticleId(String articleId) {
+        this.articleId = articleId;
+    }
+
+    @DynamoDbSecondaryPartitionKey(indexNames = {"gsi_sku_lookup"})
+    public String getSku() {
+        return sku;
+    }
+
+    public void setSku(String sku) {
+        this.sku = sku;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public void setPrice(String price) {
+        this.price = price;
+    }
+
+    public Long getInventory() {
+        return inventory;
+    }
+
+    public void setInventory(Long inventory) {
+        this.inventory = inventory;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public Boolean getFeatured() {
+        return isFeatured;
+    }
+
+    public void setFeatured(Boolean featured) {
+        isFeatured = featured;
+    }
+
+    @DynamoDbSecondaryPartitionKey(indexNames = {"gsi_catalog_lookup"})
+    public String getCatalogId() {
+        return catalogId;
+    }
+
+    public void setCatalogId(String catalogId) {
+        this.catalogId = catalogId;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(String updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Map<String, DynamicFieldValue> getDynamicFields() {
+        return dynamicFields;
+    }
+
+    public void setDynamicFields(Map<String, DynamicFieldValue> dynamicFields) {
+        this.dynamicFields = dynamicFields;
+    }
+
+    @Override
+    public String toString() {
+        return "Article::[articleId=" + articleId
+                + ", sku=" + sku
+                + ", name='" + name
+                + "', price=" + price
+                + ", inventory=" + inventory
+                + ", state=" + state
+                + ", isFeatured=" + isFeatured
+                + ", catalogId=" + catalogId
+                + ", createdAt=" + createdAt
+                + ", updatedAt=" + updatedAt
+                + ", dynamicFields (Size) =" + dynamicFields.size()
+                + "]";
+    }
+}

--- a/asset-service/src/main/java/com/sakai/inventory/api/model/Catalog.java
+++ b/asset-service/src/main/java/com/sakai/inventory/api/model/Catalog.java
@@ -1,19 +1,78 @@
 package com.sakai.inventory.api.model;
 
-//import lombok.Getter;
-//import lombok.Setter;
-//import lombok.ToString;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 
-import java.io.Serializable;
-
-//@Getter
-//@Setter
-//@ToString
-public class Catalog implements Serializable {
-    private String id;
+@DynamoDbBean
+public class Catalog {
+    private String catalogId;
     private String name;
     private String description;
     private String color;
-    private Long productCount;
     private String createdAt;
+    private String updatedAt;
+
+    public Catalog(String name) {
+        this.name = name;
+    }
+
+    @DynamoDbPartitionKey
+    public String getCatalogId() {
+        return catalogId;
+    }
+
+    public void setCatalogId(String catalogId) {
+        this.catalogId = catalogId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(String updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public String toString() {
+        return "Catalog::[" +
+                "catalogId='" + catalogId + '\'' +
+                ", name='" + name + '\'' +
+                ", color='" + color + '\'' +
+                ", createdAt='" + createdAt + '\'' +
+                ", updatedAt='" + updatedAt + '\'' +
+                ']';
+    }
 }

--- a/asset-service/src/main/java/com/sakai/inventory/api/model/DynamicFieldValue.java
+++ b/asset-service/src/main/java/com/sakai/inventory/api/model/DynamicFieldValue.java
@@ -1,0 +1,41 @@
+package com.sakai.inventory.api.model;
+
+public class DynamicFieldValue {
+    private String name;
+    private String type; // "TEXT", "NUMBER", "BOOLEAN", "DATE", etc.
+    private Object value; // Eigentlicher Inhalt.
+
+    public DynamicFieldValue() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "DynamicFieldValue::[name=" + name
+                + "type=" + type
+                + "]";
+    }
+}

--- a/asset-service/src/test/java/com/sakai/inventory/api/handler/GetCatalogsHandlerTest.java
+++ b/asset-service/src/test/java/com/sakai/inventory/api/handler/GetCatalogsHandlerTest.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -14,6 +15,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("Automatically generated tests for GetCatalogsHandler.")
 class GetCatalogsHandlerTest {
 
     private GetCatalogsHandler handler;
@@ -27,6 +29,7 @@ class GetCatalogsHandlerTest {
     }
 
     @Test
+    @DisplayName("Test GetCatalogsHandler. It should return success response.")
     void handleRequest_ShouldReturnSuccessResponse() {
         // Arrange
         APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
@@ -37,7 +40,7 @@ class GetCatalogsHandlerTest {
         // Assert
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(200);
-        assertThat(response.getBody()).isEqualTo("{\"message\": \"Lambda works successfully\"}");
+        assertThat(response.getBody()).isNotBlank();
 
         Map<String, String> headers = response.getHeaders();
         assertThat(headers).isNotNull();


### PR DESCRIPTION
DTOs und Modelle für `Artikel` und `Katalog` mit dynamischen Feldern hinzugefügt. Test- und Dummy-Daten in 'GetCatalogsHandler' zum Testen von Artikeln und Serialisieren von Antworten. Unit-Tests für die Abdeckung aktualisiert.