### PR TITLE
refs # 3 - Dokumentation, Testdaten und lokale Entwicklung für Dynamo…

### DIFF
--- a/asset-service/template.yaml
+++ b/asset-service/template.yaml
@@ -36,6 +36,33 @@ Resources:
         Ref: ApplicationResourceGroup
       AutoConfigurationEnabled: 'true'
 
+  #########################################
+  # DynamoDB Table
+  #########################################
+  InventoryTable:
+    Type: AWS::DynamoDB::Table
+    Description: Inventory table with articles und catalogs (SAKAI Project).
+    Properties:
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: partitionKey
+          AttributeType: S
+        - AttributeName: sortKey
+          AttributeType: S
+        - AttributeName: SKU
+          AttributeType: S
+      KeySchema:
+        - AttributeName: partitionKey
+          KeyType: HASH
+        - AttributeName: sortKey
+          KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: SKU-index
+          KeySchema:
+            - AttributeName: SKU
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
 Outputs:
   ApiUnitApi:
     Description: API Gateway endpoint URL for Prod stage for GetCatalogs function.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,327 @@
+## LocalStack für lokale Entwicklung.
+
+**LocalStack** ist ein Cloud-Service-Emulator, welcher als Docker-Container auf dem lokalen Rechner läuft. Er simuliert
+die APIs von Amazon Web Services (AWS), sodass Cloud-Anwendungen lokal entwickelt und getestet werden können,
+ohne sich tatsächlich mit den echten AWS-Servern verbinden zu müssen. Vorteil: man braucht kein AWS-Konto, es entstehen
+keine Kosten für die Nutzung von AWS-Infrastruktur, man braucht keine Internetverbindung - Cloud-Anwendung kann lokal
+und offline getestet werden.
+
+## 🚀 1: LocalStack starten.
+
+In den Ordner mit `docker-compose.yaml` Datei navigieren und von dort LocalStack Container starten:
+
+```bash
+docker compose up -d
+```
+
+Prüfen ob LocalStack läuft:
+
+```bash
+aws --endpoint-url=http://localhost:4566 sts get-caller-identity
+```
+
+---
+
+## 🗃️ 2: DynamoDB-Tabelle auf LocalStack erstellen.
+
+DynamoDB Tabelle genau wie in **template.yaml** definiert erstellen:
+
+```bash
+aws --endpoint-url=http://localhost:4566 dynamodb create-table \
+    --table-name InventoryTable \
+    --attribute-definitions \
+        AttributeName=partitionKey,AttributeType=S \
+        AttributeName=sortKey,AttributeType=S \
+        AttributeName=SKU,AttributeType=S \
+    --key-schema \
+        AttributeName=partitionKey,KeyType=HASH \
+        AttributeName=sortKey,KeyType=RANGE \
+    --billing-mode PAY_PER_REQUEST \
+    --global-secondary-indexes \
+        '[{"IndexName": "SKU-index", "KeySchema": [{"AttributeName": "SKU", "KeyType": "HASH"}], "Projection": {"ProjectionType": "ALL"}}]'
+
+```
+
+Erstellte Tabelle prüfen:
+
+```bash
+aws --endpoint-url=http://localhost:4566 dynamodb list-tables
+```
+
+```bash
+aws --endpoint-url=http://localhost:4566 dynamodb describe-table --table-name InventoryTable
+```
+
+---
+
+## 📊 3: Testdaten in DynamoDB einfügen
+
+Beispiel-Katalog hinzufügen:
+
+```bash
+aws --endpoint-url=http://localhost:4566 dynamodb put-item \
+    --table-name InventoryTable \
+    --item '{
+        "partitionKey": {"S": "CAT#CAT-01"},
+        "sortKey": {"S": "METADATA"},
+        "color": {"S": "#fade55"},
+        "name": {"S": "MacBooks Pro"},
+        "description": {"S": ""},
+        "createdAt": {"S": "1999.99"},
+        "updatedAt": {"S": "25"}
+    }'
+```
+
+Beispiel Artikel:
+
+```bash
+aws --endpoint-url=http://localhost:4566 dynamodb put-item \
+    --table-name InventoryTable \
+    --item '{
+  "partitionKey": {"S": "ARTCL#ART-12"},
+  "sortKey": {"S": "ARTCL#ART-12"},
+  "createdAt": {"S": "2026-02-05T14:30:00Z"},
+  "description": {"S": ""},
+  "dynamicFields": {"M": {}},
+  "imageUrl": {"S": "http://s3"},
+  "inventory": {"N": "1"},
+  "isFeatured": {"BOOL": true},
+  "name": {"S": "iPhone 15"},
+  "price": {"S": ""},
+  "SKU": {"S": "SKU-12-0"},
+  "state": {"S": "AVAILABLE"},
+  "updatedAt": {"S": ""}
+}'
+```
+
+Weitere Beispieldaten:
+
+```bash
+aws --endpoint-url=http://kocalhost:4566 dynamodb put-item \
+    --table-name InventoryTable \
+    --item '{
+    "partitionKey": {"S": ARTCL#ART-001"},
+    "sortKey": {"S": ARTCL#ART-001"},
+    "createdAt": {"S": "2024-01-15T10:30:00Z"},
+    "description": {"S": "Eine gut erhaltene Porzellanvase mit blau-weißen Mustern, ca. 16. Jahrhundert."},
+    "dynamicFields": {"M": {}}
+    "imageUrl": {"S": "https://inventory-images.s3.eu-central-1.amazonaws.com/ming_vase.jpg"},
+    "inventory": {"N": "1"},
+    "isFeatured": {"BOOL": true},
+    "name": {"S": "Antike Vase aus der Ming-Dynastie"},
+    "price": {"S": "Nicht bewertet"},
+    "SKU": {"S": "SKU-7001"},
+    "state": {"S": "AVAILABLE"},
+    "updatedAt": {"S": "2024-03-10T14:22:00Z"},
+    }'
+```
+
+Artikel im Katalog:
+
+```bash
+aws --endpoint-url=http://localhost:4566 dynamodb put-item \
+    --table-name InventoryTable \
+    --item '{
+  "partitionKey": {"S": "CAT#CAT-01"},
+  "sortKey": {"S": "ARTCL#ART-12"},
+  "catalogId": {"S": "CAT-01"},
+  "createdAt": {"S": "2026-02-05T14:30:00Z"},
+  "description": {"S": ""},
+  "dynamicFields": {"M": {}},
+  "imageUrl": {"S": "http://s3"},
+  "inventory": {"N": "1"},
+  "isFeatured": {"BOOL": true},
+  "name": {"S": "iPhone 15"},
+  "price": {"S": ""},
+  "SKU": {"S": "SKU-12-0"},
+  "state": {"S": "AVAILABLE"},
+  "updatedAt": {"S": ""}
+}'
+```
+
+Alle Daten anzeigen:
+
+```bash
+aws --endpoint-url=http://localhost:4566 dynamodb scan --table-name InventoryTable
+```
+
+---
+
+## 🔧 5: Lambda-Funktion mit SAM lokal testen.
+
+### A) Projekt-Struktur vorbereiten.
+
+```
+asset-service/
+├── template.yaml
+├── template-local.yaml
+├── src/
+│   └── com/sakai/inventory/api/handler/
+│       └── GetCatalogsHandler.java
+├── events/
+│   └── test-event.json
+├── env.json
+└── docker-compose.yaml
+```
+
+**`events/test-event.json`:**
+
+```json
+{
+  "httpMethod": "GET",
+  "path": "/catalogs",
+  "queryStringParameters": null
+}
+```
+
+**`env.json`:**
+
+```json
+{
+  "GetCatalogsHandler": {
+    "DYNAMODB_ENDPOINT": "http://host.docker.internal:4566",
+    "AWS_ACCESS_KEY_ID": "test",
+    "AWS_SECRET_ACCESS_KEY": "test",
+    "AWS_REGION": "eu-central-1"
+  }
+}
+```
+
+### B) SAM lokal ausführen.
+
+```bash
+# 1. SAM-App bauen (für Java)
+sam build --use-container
+
+# 2. Lambda-Funktion lokal testen
+sam local invoke GetCatalogsHandler \
+    --event events/test-event.json \
+    --env-vars env.json \
+    --docker-network host  # Für Mac/Windows: --docker-network bridge
+
+# Alternative: Mit Debugging
+sam local invoke GetCatalogsHandler \
+    --event events/test-event.json \
+    --env-vars env.json \
+    --debug-port 5858 \
+    --docker-network host
+```
+
+---
+
+## 🌐 6: Komplette API mit SAM lokal starten.
+
+```bash
+# 1. Vollständige API lokal starten (API Gateway + Lambda)
+sam local start-api \
+    --port 3000 \
+    --env-vars env.json \
+    --docker-network host \
+    --warm-containers LAZY
+
+# 2. API testen (in neuem Terminal)
+curl http://localhost:3000/catalogs
+```
+
+---
+
+## 🐛 Debugging.
+
+### A) Debugging mit SAM und IDE:
+
+```bash
+# 1. SAM mit Debug-Port starten
+sam local invoke GetCatalogsHandler \
+    --event events/test-event.json \
+    --env-vars env.json \
+    --debug-port 5858 \
+    --docker-network host
+
+# 2. In IDE (z.B. IntelliJ):
+# - Run → Edit Configurations → "+" → Remote JVM Debug
+# - Host: localhost, Port: 5858
+# - Start Debug Session
+```
+
+### B) Logs anzeigen:
+
+```bash
+# LocalStack Logs
+docker logs localstack -f
+
+# Lambda Logs (wenn auf LocalStack deployed)
+aws --endpoint-url=http://localhost:4566 logs describe-log-groups
+```
+
+---
+
+## 🔄 (optional) Komplettes Deployment auf LocalStack.
+
+Wenn du alles auf LocalStack haben willst (nicht nur SAM lokal):
+
+```bash
+# 1. CloudFormation Stack auf LocalStack deployen
+aws --endpoint-url=http://localhost:4566 cloudformation create-stack \
+    --stack-name asset-service \
+    --template-body file://template-local.yaml \
+    --capabilities CAPABILITY_IAM
+
+# 2. Status prüfen
+aws --endpoint-url=http://localhost:4566 cloudformation describe-stacks \
+    --stack-name asset-service
+
+# 3. Lambda auf LocalStack erstellen (wenn du den Code hast)
+aws --endpoint-url=http://localhost:4566 lambda create-function \
+    --function-name GetCatalogsHandler \
+    --runtime java21 \
+    --handler com.sakai.inventory.api.handler.GetCatalogsHandler::handleRequest \
+    --role arn:aws:iam::000000000000:role/lambda-role \
+    --environment Variables="{DYNAMODB_ENDPOINT=http://localhost:4566,AWS_ACCESS_KEY_ID=test,AWS_SECRET_ACCESS_KEY=test,AWS_REGION=eu-central-1}" \
+    --code S3Bucket="hot-reload",S3Key="/tmp/localstack/zipfile.jar"  # Vereinfacht
+
+# 4. Lambda testen
+aws --endpoint-url=http://localhost:4566 lambda invoke \
+    --function-name GetCatalogsHandler \
+    --payload '{}' \
+    response.json
+
+cat response.json
+```
+
+---
+
+## 📝 **Zusammenfassung der besten Vorgehensweise:**
+
+### **Für einfache Entwicklung und Debugging:**
+
+1. **LocalStack für DynamoDB** (Tabellen + Daten)
+2. **SAM für Lambda lokal** (Ausführung + Debugging)
+3. **SAM Local API für API Gateway** (lokale Endpoints)
+
+### **Kurzanleitung:**
+
+```
+# 1. Starte LocalStack
+docker compose up -d
+
+# 2. Erstelle DynamoDB Tabelle
+aws --endpoint-url=http://localhost:4566 dynamodb create-table ... 
+
+# 3. Füge Testdaten ein
+aws --endpoint-url=http://localhost:4566 dynamodb put-item ...
+
+# 4. Baue Lambda-Funktion
+sam build --use-container
+
+# 5. Teste Lambda lokal
+sam local invoke GetCatalogsHandler --event events/test-event.json --env-vars env.json
+
+# 6. Oder starte komplette API
+sam local start-api --port 3000 --env-vars env.json
+```
+
+### **Tipps:**
+
+- **Für Docker-Netzwerk auf Mac/Windows:** Nutze `host.docker.internal` statt `localhost` in deinem Java-Code
+- **Umgebungsvariablen:** Definiere alle AWS Credentials in `env.json`
+- **Debugging:** Nutze `--debug-port` mit SAM und verbinde deine IDE

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,47 @@
+version: '3.8'
+
+services:
+  localstack:
+    container_name: localstack
+    image: localstack/localstack:latest
+    ports:
+      # API Gateway
+      - "4566:4566"
+      - "4510-4559:4510-4559"
+    environment:
+      # Services, die gestartet werden sollen
+      - SERVICES=s3,sqs,dynamodb,lambda,apigateway,cloudformation,cloudwatch,iam,sts,ssm,events,ses,sns,stepfunctions,logs
+
+      # Persistenz aktivieren (optional)
+      - PERSISTENCE=1
+      - DATA_DIR=/var/lib/localstack/data
+
+      # Für Lambda Funktionen
+      - LAMBDA_EXECUTOR=docker-reuse
+      # - LAMBDA_REMOTE_DOCKER=true
+      - LAMBDA_DOCKER_NETWORK=localstack_default
+
+      # Edge Port (wichtig für alle Services)
+      - EDGE_PORT=4566
+
+      # Debug Modus (optional)
+      - DEBUG=1
+
+      # AWS Credentials für lokale Entwicklung
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
+      - AWS_DEFAULT_REGION=eu-central-1
+    volumes:
+      # Für persistente Daten
+      - localstack_data:/var/lib/localstack
+
+      # Docker Socket für Lambda-Funktionen
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - localstack-network
+volumes:
+  localstack_data:
+    driver: local
+networks:
+  localstack-network:
+    driver: bridge

--- a/docs/dynamodb/inventory.json
+++ b/docs/dynamodb/inventory.json
@@ -1,0 +1,531 @@
+{
+  "articles": [
+    {
+      "PutRequest": {
+        "Item": {
+          "partitionKey": {
+            "S": "ARTICLES"
+          },
+          "sortKey": {
+            "S": "ARTICLES#SKU-7001#871e9bf3-e1e8-4413-8f35-eb4757a5cfe8"
+          },
+          "sku": {
+            "S": "SKU-7001"
+          },
+          "name": {
+            "S": "Antike Vase aus der Ming-Dynastie"
+          },
+          "description": {
+            "S": "Eine gut erhaltene Porzellanvase mit blau-weißen Mustern, ca. 16. Jahrhundert."
+          },
+          "price": {
+            "N": "0"
+          },
+          "inventory": {
+            "N": "1"
+          },
+          "imageUrl": {
+            "S": "https://inventory-images.s3.eu-central-1.amazonaws.com/ming_vase.jpg"
+          },
+          "state": {
+            "S": "AVAILABLE"
+          },
+          "isFeatured": {
+            "BOOL": true
+          },
+          "createdAt": {
+            "S": "2024-01-15T10:30:00Z"
+          },
+          "updatedAt": {
+            "S": "2024-03-10T14:22:00Z"
+          },
+          "dynamicFields": {
+            "M": {}
+          }
+        }
+      }
+    },
+    {
+      "PutRequest": {
+        "Item": {
+          "partitionKey": {
+            "S": "ARTICLES"
+          },
+          "sortKey": {
+            "S": "ARTICLES#SKU-7002#45c14215-9be0-4aa8-a038-3c2c6ec539e2"
+          },
+          "sku": {
+            "S": "SKU-7002"
+          },
+          "name": {
+            "S": "Barock-Gemälde 'Landschaft mit Fluss'"
+          },
+          "description": {
+            "S": "Öl auf Leinwand, 18. Jahrhundert, Rahmen original."
+          },
+          "price": {
+            "N": "0"
+          },
+          "inventory": {
+            "N": "1"
+          },
+          "imageUrl": {
+            "S": "https://inventory-images.s3.eu-central-1.amazonaws.com/barock_painting.jpg"
+          },
+          "state": {
+            "S": "UNDER_EVALUATION"
+          },
+          "isFeatured": {
+            "BOOL": false
+          },
+          "createdAt": {
+            "S": "2024-02-01T09:15:00Z"
+          },
+          "updatedAt": {
+            "S": "2024-02-28T16:45:00Z"
+          },
+          "dynamicFields": {
+            "M": {}
+          }
+        }
+      }
+    },
+    {
+      "PutRequest": {
+        "Item": {
+          "partitionKey": {
+            "S": "ARTICLES"
+          },
+          "sortKey": {
+            "S": "ARTICLES#SKU-7003#1216143d-2679-4d76-984f-a9a755dc730f"
+          },
+          "sku": {
+            "S": "SKU-7003"
+          },
+          "name": {
+            "S": "Renaissance-Bronzeskulptur 'Reiter'"
+          },
+          "description": {
+            "S": "Kleine Bronzestatue, italienische Arbeit, 17. Jahrhundert."
+          },
+          "price": {
+            "N": "0"
+          },
+          "inventory": {
+            "N": "1"
+          },
+          "imageUrl": {
+            "S": "https://inventory-images.s3.eu-central-1.amazonaws.com/bronze_rider.jpg"
+          },
+          "state": {
+            "S": "AVAILABLE"
+          },
+          "isFeatured": {
+            "BOOL": true
+          },
+          "createdAt": {
+            "S": "2023-11-20T11:00:00Z"
+          },
+          "updatedAt": {
+            "S": "2024-01-05T12:30:00Z"
+          },
+          "dynamicFields": {
+            "M": {
+              "provenance": {
+                "S": "Sammlung Dr. Schmidt, Auktion Haus Müller 2019"
+              },
+              "material": {
+                "S": "Bronze (gepatiniert)"
+              },
+              "weight_kg": {
+                "S": "2.8 kg"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "PutRequest": {
+        "Item": {
+          "partitionKey": {
+            "S": "ARTICLES"
+          },
+          "sortKey": {
+            "S": "ARTICLES#SKU-7004#68081736-e8ef-4bb0-b21c-36349344b394"
+          },
+          "sku": {
+            "S": "SKU-7004"
+          },
+          "name": {
+            "S": "Art Deco Sekretär aus Nussbaum"
+          },
+          "description": {
+            "S": "Möbelstück mit Intarsien, Frankreich um 1925."
+          },
+          "price": {
+            "N": "0"
+          },
+          "inventory": {
+            "N": "1"
+          },
+          "imageUrl": {
+            "S": "https://inventory-images.s3.eu-central-1.amazonaws.com/artdeco_desk.jpg"
+          },
+          "state": {
+            "S": "IN_USE"
+          },
+          "isFeatured": {
+            "BOOL": false
+          },
+          "createdAt": {
+            "S": "2023-10-05T14:20:00Z"
+          },
+          "updatedAt": {
+            "S": "2024-03-15T10:10:00Z"
+          },
+          "dynamicFields": {
+            "M": {}
+          }
+        }
+      }
+    },
+    {
+      "PutRequest": {
+        "Item": {
+          "partitionKey": {
+            "S": "ARTICLES"
+          },
+          "sortKey": {
+            "S": "ARTICLES#SKU-7005#90302335-efe2-4d08-abe2-0f9754d886d7"
+          },
+          "sku": {
+            "S": "SKU-7005"
+          },
+          "name": {
+            "S": "Samurai-Rüstung (Gusoku)"
+          },
+          "description": {
+            "S": "Komplette Rüstung aus Eisen, Seide und Leder, Edo-Periode."
+          },
+          "price": {
+            "N": "0"
+          },
+          "inventory": {
+            "N": "1"
+          },
+          "imageUrl": {
+            "S": "https://inventory-images.s3.eu-central-1.amazonaws.com/samurai_armor.jpg"
+          },
+          "state": {
+            "S": "AVAILABLE"
+          },
+          "isFeatured": {
+            "BOOL": true
+          },
+          "createdAt": {
+            "S": "2024-03-01T08:45:00Z"
+          },
+          "updatedAt": {
+            "S": "2024-03-01T08:45:00Z"
+          },
+          "dynamicFields": {
+            "M": {}
+          }
+        }
+      }
+    },
+    {
+      "PutRequest": {
+        "Item": {
+          "partitionKey": {
+            "S": "ARTICLES"
+          },
+          "sortKey": {
+            "S": "ARTICLES#SKU-7006#3e95353a-5a66-4226-93a1-2fcd625c3627"
+          },
+          "sku": {
+            "S": "SKU-7006"
+          },
+          "name": {
+            "S": "Persischer Teppich 'Isfahan'"
+          },
+          "description": {
+            "S": "Handgeknüpfter Seidenteppich, 2.3 x 1.6 m, Anfang 20. Jh."
+          },
+          "price": {
+            "N": "0"
+          },
+          "inventory": {
+            "N": "1"
+          },
+          "imageUrl": {
+            "S": "https://inventory-images.s3.eu-central-1.amazonaws.com/isfahan_carpet.jpg"
+          },
+          "state": {
+            "S": "UNDER_EVALUATION"
+          },
+          "isFeatured": {
+            "BOOL": false
+          },
+          "createdAt": {
+            "S": "2024-02-10T13:10:00Z"
+          },
+          "updatedAt": {
+            "S": "2024-02-25T09:30:00Z"
+          },
+          "dynamicFields": {
+            "M": {}
+          }
+        }
+      }
+    },
+    {
+      "PutRequest": {
+        "Item": {
+          "partitionKey": {
+            "S": "ARTICLES"
+          },
+          "sortKey": {
+            "S": "ARTICLES#SKU-7007#cb43febd-ea3e-4e28-94c5-dc19fd69d131"
+          },
+          "sku": {
+            "S": "SKU-7007"
+          },
+          "name": {
+            "S": "Moderne Skulptur 'Equilibrium'"
+          },
+          "description": {
+            "S": "Abstrakte Stahlskulptur des zeitgenössischen Künstlers M. Chen."
+          },
+          "price": {
+            "N": "0"
+          },
+          "inventory": {
+            "N": "1"
+          },
+          "imageUrl": {
+            "S": "https://inventory-images.s3.eu-central-1.amazonaws.com/equilibrium_sculpture.jpg"
+          },
+          "state": {
+            "S": "AVAILABLE"
+          },
+          "isFeatured": {
+            "BOOL": true
+          },
+          "createdAt": {
+            "S": "2024-01-30T16:00:00Z"
+          },
+          "updatedAt": {
+            "S": "2024-03-12T11:20:00Z"
+          },
+          "dynamicFields": {
+            "M": {
+              "artist": {
+                "S": "M. Chen"
+              },
+              "creation_year": {
+                "S": "2022"
+              },
+              "technique": {
+                "S": "Geschweißter Edelstahl"
+              },
+              "exhibitions": {
+                "S": "Biennale Venedig 2023"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "PutRequest": {
+        "Item": {
+          "partitionKey": {
+            "S": "ARTICLES"
+          },
+          "sortKey": {
+            "S": "ARTICLES#SKU-7008#9dc306ed-8428-4a05-883e-9cdaa6f4072d"
+          },
+          "sku": {
+            "S": "SKU-7008"
+          },
+          "name": {
+            "S": "Klassische Violine 'Stradivarius-Kopie'"
+          },
+          "description": {
+            "S": "Geige deutscher Arbeit um 1900, ausgezeichneter Klang."
+          },
+          "price": {
+            "N": "0"
+          },
+          "inventory": {
+            "N": "1"
+          },
+          "imageUrl": {
+            "S": "https://inventory-images.s3.eu-central-1.amazonaws.com/violin_strad_copy.jpg"
+          },
+          "state": {
+            "S": "AVAILABLE"
+          },
+          "isFeatured": {
+            "BOOL": false
+          },
+          "createdAt": {
+            "S": "2023-12-15T10:45:00Z"
+          },
+          "updatedAt": {
+            "S": "2024-02-20T15:15:00Z"
+          },
+          "dynamicFields": {
+            "M": {}
+          }
+        }
+      }
+    },
+    {
+      "PutRequest": {
+        "Item": {
+          "partitionKey": {
+            "S": "ARTICLES"
+          },
+          "sortKey": {
+            "S": "ARTICLES#SKU-7009#f5951633-3bf1-4c70-bff1-11d715f751ae"
+          },
+          "sku": {
+            "S": "SKU-7009"
+          },
+          "name": {
+            "S": "Ägyptische Uschebti-Figur"
+          },
+          "description": {
+            "S": "Fayence-Statuette, Spätzeit, für Grabbeigabe bestimmt."
+          },
+          "price": {
+            "N": "0"
+          },
+          "inventory": {
+            "N": "1"
+          },
+          "imageUrl": {
+            "S": "https://inventory-images.s3.eu-central-1.amazonaws.com/ushabti_figure.jpg"
+          },
+          "state": {
+            "S": "RESERVED"
+          },
+          "isFeatured": {
+            "BOOL": false
+          },
+          "createdAt": {
+            "S": "2024-02-28T12:30:00Z"
+          },
+          "updatedAt": {
+            "S": "2024-03-14T17:00:00Z"
+          },
+          "dynamicFields": {
+            "M": {}
+          }
+        }
+      }
+    },
+    {
+      "PutRequest": {
+        "Item": {
+          "partitionKey": {
+            "S": "ARTICLES"
+          },
+          "sortKey": {
+            "S": "ARTICLES#SKU-7010#ca5c186c-adbb-4578-b9c8-c0dc19945af1"
+          },
+          "sku": {
+            "S": "SKU-7010"
+          },
+          "name": {
+            "S": "Jugendstil-Vase von Émile Gallé"
+          },
+          "description": {
+            "S": "Glasvase mit eingeschliffenen Pflanzendekoren, Frankreich um 1900."
+          },
+          "price": {
+            "N": "0"
+          },
+          "inventory": {
+            "N": "1"
+          },
+          "imageUrl": {
+            "S": "https://inventory-images.s3.eu-central-1.amazonaws.com/galle_vase.jpg"
+          },
+          "state": {
+            "S": "AVAILABLE"
+          },
+          "isFeatured": {
+            "BOOL": true
+          },
+          "createdAt": {
+            "S": "2024-01-10T09:30:00Z"
+          },
+          "updatedAt": {
+            "S": "2024-03-05T14:05:00Z"
+          },
+          "dynamicFields": {
+            "M": {}
+          }
+        }
+      }
+    },
+    {
+      "PutRequest": {
+        "Item": {
+          "partitionKey": {
+            "S": "CATALOGS"
+          },
+          "sortKey": {
+            "S": "CATALOGS#CAT-125#METADATA"
+          },
+          "name": {
+            "S": "Musik"
+          },
+          "description": {
+            "S": "Alle Artikel zu Musik."
+          },
+          "createdAt": {
+            "S": "2024-01-01T00:00:00Z"
+          },
+          "updatedAt": {
+            "S": "2024-01-01T00:00:00Z"
+          },
+          "color": {
+            "S": "#fade55"
+          }
+        }
+      }
+    },
+    {
+      "PutRequest": {
+        "Item": {
+          "partitionKey": {
+            "S": "CATALOGS"
+          },
+          "sortKey": {
+            "S": "CATALOGS#CAT-123#METADATA"
+          },
+          "name": {
+            "S": "Phones"
+          },
+          "description": {
+            "S": "Alle Apple Phones."
+          },
+          "createdAt": {
+            "S": "2024-02-02T10:00:00Z"
+          },
+          "updatedAt": {
+            "S": "2024-02-02T10:00:00Z"
+          },
+          "color": {
+            "S": "#fcdsss"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/dynamodb/schema-design.md
+++ b/docs/dynamodb/schema-design.md
@@ -1,0 +1,92 @@
+## DynamoDB Schema Design – Inventory ans Assets Management.
+
+Für Schema Desing wird Single Table Pattern angewendet. Es werden sowohl Artikle (Article) als auch Kataloge (Im
+Frontend: eine Samlung von Artiklen bzw. Organisationseinheit für Artikle) in einer Tabelle gespeichert.
+
+### Tabelle: `ArticlesAndCategory` .
+
+| Attribut          | Type    | Attribut von     | Optional | Beschreibung                                   |
+|-------------------|---------|------------------|----------|------------------------------------------------|
+| partitionKey (PK) | String  | Article, Catalog | nein     | Partition key. Primärschlüssel (PK)            |
+| sortKey      (PK) | String  | Article, Catalog | nein     | Sort Key. Primärschlüssel (PK)                 |
+| name              | String  | Article, Catalog | nein     | Artikel- oder Katalogname. Freitext.           |
+| description       | String  | Article, Catalog | ja       | Freitext.                                      |
+| price             | Number  | Article          | nein     |                                                |
+| imageUrl          | String  | Article          | ja       |                                                |
+| status            | String  | Article          | nein     | Werte: "active", "inactive"                    |
+| isFeatured        | Boolean | Article          | nein     |                                                |
+| dynamicFields     | Map     | Article          | ja       | Benutzerdefinierte Attribute.                  |
+| createdAt         | String  | Article, Catalog | nein     | ISO 8601 Timestamp                             |
+| updatedAt         | String  | Article, Catalog | nein     | ISO 8601 Timestamp                             |
+| color             | String  | Catalog          | ja       | Farbe für ein Katalog (Catalog). Hexadezimal.  |
+| inventory         | Number  | Article          | nein     | Insgesamt auf Lager.                           |
+| sku               | String  | Article          | nein     | Stock Keeping Unit.                            |
+| state             | String  | Article          | nein     | Verfügberkeit und/oder Zustand eines Artikels. |
+
+**Single-Table-Design**
+Singe-Table Design spart Kosten, vereinfacht Rechteverwaltung und erlaubt es, zusammengehörige Daten mit einem einzigen
+Request zu laden.
+
+**Primäschlüssel:**
+Primärschlüssel (PK) wird aus `partitionKey` und `sortKey` zusammengestzt. Um Atrikel von Kategorien zu unterscheiden,
+wir `partitionKey` von Artikel "ARTKL" enthalten und `partitionKey` von Kategorie "CAT". `partitionKey` kann weitere
+Attribute enthalten, um Suche und Filterung zu ermöglichen. Attribute werden mit "#" von einander getrennt. Beispiel für
+`partitionKey` von einem Artikel: "ARTCL#SKU-001", wo "SKU-001" SKU von Artekel ist. Das macht die Suche nach einem
+Artikel mit SKU "SKU-001" möglich ohne gesammte Tabelle zu Scannen.
+
+### Global Secondary Indexes (GSI).
+
+**GSI_SKU:**
+Vorerst aufgehoben: Wird in der aktuellen Version nicht benötigt.
+
+**GSI_NameLookup (Namensuche):**
+Um die Suche nach Produktnamen zu ermöglichen, ohne dabei die gesamte Tabelle zu Scannen, wird ein Global Secondary
+Index auf Felder "name" (partitionKey) und "sku" (sortKey) gesetzt.
+
+**Suche mit GSI_NameLookup**.
+
+- Artikel nach Namen zu suchen: Mit Query, wo `partitionKey`=name und `sortKey` bleibt leer.
+- Artikel nach Namen suchen, aber Suchergebnise mit sku abgrenzen: Mit Query, wo `partitionKey`=name und `sortKey`=sku
+  ist.
+
+---
+
+### Beispieltabelle mit fiktiven Daten.
+
+| partitionKey      | sortKey                          | color   | createdAt            | description   | imageUrl            | inv. | isFeatured | name         | price | SKU     | state     | updatedAt  |
+|-------------------|----------------------------------|---------|----------------------|---------------|---------------------|------|------------|--------------|-------|---------|-----------|------------|
+| CATALOGS          | CATALOGS#CAT-125#METADATA        | #fade55 | 2026-02-05T14:30:00Z |               |                     |      |            | phones       |       |         |           | 2026-02-01 |
+| CATALOGS          | CATALOGS#CAT-123#METADATA        | #fcdsss | 2026-02-05T14:30:01Z | DELL Laptops. |                     |      |            | Laptops      |       |         |           | 2026-02-01 |
+| ARTICLES          | ARTICLES#SKU-120#<UUID>          |         | 2026-02-05T14:30:00Z |               | http://s3.img01.png | 1    | true       | iPhone 15    | 0     | SKU-120 | IN_USE    |            |
+| ARTICLES          | ARTICLES#SKU-120#<UUID>          |         | 2026-02-05T14:31:00Z |               | http://s3.img01.png | 1    | true       | iPhone 15    | 0     | SKU-120 | AVAILABLE |            |
+| ARTICLES          | ARTICLES#SKU-030#<UUID>          |         | 2026-02-05T14:30:01Z |               | http://s3.img03.png | 1    | false      | Samsung S24  | 0     | SKU-030 | IN_USE    | 2026-02-07 |
+| ARTICLES          | ARTICLES#SKU-123#<UUID>          |         | 2026-02-06T14:31:01Z | Gebraucht.    | http://s3.img04.png | 1    | false      | IPhone 15 SE | 0     | SKU-123 | AVAILABLE | 2026-02-07 |
+| CATALOGS#ARTICLES | CATALOGS#CAT-125#ARTICLES#<UUID> |         | 2026-02-05T14:30:00Z |               |                     |      |            |              |       |         |           |            |
+| CATALOGS#ARTICLES | CATALOGS#CAT-125#ARTICLES#<UUID> |         | 2026-02-05T14:30:01Z |               |                     |      |            |              |       |         |           |            |
+
+---
+
+### Suchen.
+
+Einzelne Items werden nach PK gesucht und einzelne (bestimmte) Artikel können zusätzlich noch nach deren SKU gesucht
+werden.
+
+- [x] alle Artikel finden: Mit Query, wo `partitionKey`=ARTICLES und `sortKey`=nichts (keiner).
+- [x] alle Artikel mit einem bestimmten SKU finden: Mit Query, wo `partitionKey`=ARTICLES und `sortKey`= Begins with "
+  ARTICLES#SKU-125".
+- [x] alle Artikel in Kategorie (Catalog) finden: Mit Query, wo `partitionKey`=CATALOGS#ARTICLES und `sortKey`= Begins
+  with "CATALOGS#CAT-125".
+- [x] alle Kategorien (Catalogs) finden bzw. auflisten: Mit Query, wo `partitionKey`=CATALOGS und `sortKey`=nichts (
+  keiner).
+
+---
+
+### Wertebereiche für `state`
+
+| Wert        | Bedeutung                                                                                                  |
+|-------------|------------------------------------------------------------------------------------------------------------|
+| AVAILABLE   | Der Artikel (Inventar) ist für die Anwendung bereit.                                                       |
+| IN_USE      | Der Artikel (Inventar) wird gerade genutzt, im Einsatz oder in Ausleihe.                                   |
+| RESERVED    | Der Artikel (Inventar) ist für einen bestimmten Zwekck reserviert, wurde aber noch nicht entnommen.        |
+| MAINTENANCE | Wartung, Reparatur, Qualitätsprüfung, Bestandasaufnahme (Buchhaltung).                                     |
+| RETIRED     | Der Artikel (Inventar) wird aus dem aktiven Bestand ausgeschrieben (verloren, defekt, verkauft, veraltet). |

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.sakai</groupId>
+        <artifactId>sakai-lambda-slave</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <name>SAKAI Docs</name>
+    <description>Parent POM for documentation-related projects in SAKAI.</description>
+
+    <artifactId>docs</artifactId>
+    <packaging>pom</packaging>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <packaging>pom</packaging>
     <modules>
         <module>asset-service</module>
+        <module>docs</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
refs # 3 - Dokumentation, Testdaten und lokale Entwicklung für DynamoDB hinzugefügt:
- Übergeordnetes POM (docs / pom.xml) zur Dokumentation.
- DynamoDB-Schema und Testdaten hinzugefügt (docs / dynamodb / inventory.b. json, docs/dynamodb/schema-design.md).
- Anweisungen für die lokale Entwicklung, die mit LocalStack und SAM erstellt wurden (docker / README.md).
- 'docs'-Modul in den Haupt-POM integriert.
- DynamoDB-Tabelle für Artikel und Kataloge, die im SAM-Template (Asset Service/Template.yaml).